### PR TITLE
Fix SET operation --loop functionality

### DIFF
--- a/td-usb.c
+++ b/td-usb.c
@@ -252,6 +252,7 @@ int main(int argc, char *argv[])
 		if (context->device_type->set != NULL)
 		{
 			context->device_type->set(context);
+			if (context->interval > 0)	TdTimer_Start(context->device_type->set, context, context->interval);
 		}
 		else
 		{


### PR DESCRIPTION
This PR implements the `--loop` functionality for the SET operation as described in issue #2.

## Changes

- Added timer processing to the `OPERATION_SET` case in `td-usb.c`
- Confirmed `td-usb tdpc0201 set --loop` now performs zero-clear every second

## Notes for Reviewers

- Timer implementation for SET is now similar to the existing GET operation
- Please check if this change might affect other devices using td-usb tool

Fixes #2