### PR TITLE
Add macOS support with platform detection in build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,26 @@
 CC := gcc
 CFLAGS := -Wall
 
-td-usb: td-usb.c device_types.c ./linux/tdhid-libusb.c ./linux/tdtimer-posix.c tddevice.c ./devices/*.c
-	$(CC) $(CFLAGS) td-usb.c device_types.c tddevice.c ./linux/tdhid-libusb.c ./linux/tdtimer-posix.c ./devices/*.c -o td-usb -lusb -lrt -lm
+# Platform detection
+UNAME_S := $(shell uname -s)
+
+ifeq ($(UNAME_S),Darwin)
+    # macOS specific settings
+    TIMER_SRC := ./mac/tdtimer-mac.c
+    INCLUDES := -I/opt/homebrew/include -I/opt/homebrew/include/libusb-compat-0.1
+    LDFLAGS := -L/opt/homebrew/lib
+    LIBS := -lusb -framework IOKit -framework CoreFoundation
+else
+    # Linux specific settings
+    TIMER_SRC := ./linux/tdtimer-posix.c
+    INCLUDES := 
+    LDFLAGS := 
+    LIBS := -lusb -lrt -lm
+endif
+
+td-usb: td-usb.c device_types.c ./linux/tdhid-libusb.c $(TIMER_SRC) tddevice.c ./devices/*.c
+	$(CC) $(CFLAGS) $(INCLUDES) $(LDFLAGS) td-usb.c device_types.c tddevice.c ./linux/tdhid-libusb.c $(TIMER_SRC) ./devices/*.c -o td-usb $(LIBS)
 
 clean:
-	rm td-usb
+	rm -f td-usb
 	rm -f *.o

--- a/mac/tdtimer-mac.c
+++ b/mac/tdtimer-mac.c
@@ -1,0 +1,55 @@
+// tdtimer-mac.c
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/time.h>
+#include <pthread.h>
+#include "../td-usb.h"
+#include "../tdtimer.h"
+
+static pthread_t timer_thread;
+static int (*timer_callback)(td_context_t *) = NULL;
+static td_context_t *timer_param = NULL;
+static int timer_interval = 0;
+static int timer_running = 0;
+
+static void *timer_worker(void *arg)
+{
+    while (timer_running) {
+        usleep(timer_interval * 1000); // interval is in milliseconds
+        if (timer_running && timer_callback) {
+            timer_callback(timer_param);
+        }
+    }
+    return NULL;
+}
+
+int TdTimer_Start(int (*pCallback)(td_context_t *), td_context_t *pParam, int interval)
+{
+    if (timer_running) {
+        TdTimer_Stop();
+    }
+    
+    timer_callback = pCallback;
+    timer_param = pParam;
+    timer_interval = interval;
+    timer_running = 1;
+    
+    if (pthread_create(&timer_thread, NULL, timer_worker, NULL) != 0) {
+        timer_running = 0;
+        return -1;
+    }
+    
+    return 0;
+}
+
+int TdTimer_Stop()
+{
+    if (timer_running) {
+        timer_running = 0;
+        pthread_join(timer_thread, NULL);
+    }
+    return 0;
+} 

--- a/td-usb.h
+++ b/td-usb.h
@@ -47,22 +47,25 @@
 
 #define DEBUG_PRINT(arg)    debug_print arg
 
+// Forward declaration
+typedef struct td_context_t td_context_t;
+
 typedef struct {
 	char* product_name;
 	unsigned short vendor_id;
 	unsigned short product_id;
 	uint8_t output_report_size;
 	uint8_t input_report_size;
-	int (*set)(void* context);
-	int (*save)(void* context);
-	int (*get)(void* context);
-	int (*listen)(void* context);
-	int (*init)(void* context);
-	int (*destroy)(void* context);	
+	int (*set)(td_context_t* context);
+	int (*save)(td_context_t* context);
+	int (*get)(td_context_t* context);
+	int (*listen)(td_context_t* context);
+	int (*init)(td_context_t* context);
+	int (*destroy)(td_context_t* context);	
 } td_device_t;
 
 
-typedef struct
+struct td_context_t
 {
 	int* handle;
 	td_device_t* device_type;
@@ -74,7 +77,7 @@ typedef struct
 	uint8_t verbose;
 	char* v[TD_CONTEXT_MAX_ARG_COUNT];
 	int c;
-} td_context_t;
+};
 
 
 

--- a/tdtimer.h
+++ b/tdtimer.h
@@ -1,4 +1,8 @@
 // tdtimer.h
 #pragma once
 
-int TdTimer_Start(void pCallback(void *), void *pParam, int interval);
+// Forward declaration
+typedef struct td_context_t td_context_t;
+
+int TdTimer_Start(int (*pCallback)(td_context_t *), td_context_t *pParam, int interval);
+int TdTimer_Stop();


### PR DESCRIPTION
This PR implements macOS compatibility for td-usb.

## Changes
- Added `mac/tdtimer-mac.c` with pthread-based timer implementation for macOS
- Updated `Makefile` with automatic platform detection (Darwin vs Linux)
- Fixed function pointer types in `td-usb.h` and `tdtimer.h` for type safety

## Implementation Details
- Uses Homebrew's libusb and libusb-compat packages for USB communication
- Automatic platform detection in Makefile switches between timer implementations
- Framework changes are designed to preserve existing device support architecture while adding macOS compatibility
- Requires administrator privileges (`sudo`) for USB device access on macOS
- **Note: Linux compatibility not yet re-verified after changes**

## Testing
- **macOS (Sequoia 15.5.0)**: Successfully compiled and tested with TDSN7200 sensor
- Device operations (get, list) confirmed working for TDSN7200
- **Linux**: Not re-tested after these changes

## Notes for Reviewers
- Please verify that Linux builds continue to work as expected
- **Additional testing with other device types would be valuable before merging**